### PR TITLE
Feat : Community 페이지 제작

### DIFF
--- a/src/components/atoms/Tag.tsx
+++ b/src/components/atoms/Tag.tsx
@@ -2,7 +2,6 @@ import { ReactNode } from 'react';
 
 interface TagProps {
   children: ReactNode;
-  className: string;
 }
 export default function Tag({ children }: TagProps) {
   return (

--- a/src/components/molecules/CommunityCard.tsx
+++ b/src/components/molecules/CommunityCard.tsx
@@ -1,38 +1,63 @@
-import { Link } from "react-router-dom";
-import Info from "../atoms/Info";
-import Interest from "../atoms/Interest";
-import Tag from "../atoms/Tag";
-import LogoImage from "../../assets/images/logo.png"
+import { Link } from 'react-router-dom';
+import Info from '../atoms/Info';
+import Interest from '../atoms/Interest';
+import Tag from '../atoms/Tag';
+import LogoImage from '../../assets/images/logo.png';
 
 // todo : Login 연결 후 isLike 동적으로 변경 필요함
-export default function CommunityCard ( {post}: {post: Post} ) {
-    return (
-        <div className="w-[270px] h-[340px] border border-[#d9d9d9] rounded-[5px]">
-          <Link to={`/post/${post._id}`}>
-            <div className="relative m-between h-[55%] rounded-t-[5px]">
-                {post.image ? <>
-                  <img src={post.image} className="w-[100%] h-[100%] object-cover"/>
-                </> : <>
-                  <div className="flex gap-1 items-center justify-center w-[100%] h-[100%] cafe24 text-3xl bg-[#A9907E] leading-[0.9]">
-                    <img src={LogoImage} className="w-auto h-[40%]"></img>
-                    <p>de:<br/>caffeiene</p>
-                  </div>
-                </>}
-                <Tag className="absolute bottom-[10px] right-[10px]">{post.channel.description}</Tag>
-            </div>
-          </Link>
-          <div className="flex flex-col h-[45%] justify-between">
-            <Link to={`/post/${post._id}`}>
-              <div className="p-[15px] h-[90px]">
-                <h3 className="nanum-gothic-bold text-base line-clamp-1 pr-[30px]">{JSON.parse(post.title).title}</h3>
-                <p className="nanum-gothic-regular text-sm line-clamp-2">{JSON.parse(post.title).body}</p>
+export default function CommunityCard({ post }: { post: Post }) {
+  return (
+    <div className="h-[340px] w-[270px] rounded-[5px] border border-[#d9d9d9]">
+      <Link to={`/post/${post._id}`}>
+        <div className="m-between relative h-[55%] rounded-t-[5px]">
+          {post.image ? (
+            <>
+              <img
+                src={post.image}
+                className="h-[100%] w-[100%] object-cover"
+              />
+            </>
+          ) : (
+            <>
+              <div className="cafe24 flex h-[100%] w-[100%] items-center justify-center gap-1 bg-[#A9907E] text-3xl leading-[0.9]">
+                <img src={LogoImage} className="h-[40%] w-auto"></img>
+                <p>
+                  de:
+                  <br />
+                  caffeiene
+                </p>
               </div>
-            </Link>
-            <div className="flex flex-row border-t border-[#d9d9d9] items-center justify-between mx-[10px] py-[10px] px-[5px]">
-              <Info size={30} userName={post.author.fullName} timestamp={post.createdAt}/>
-              <Interest commentCount={post.comments.length} like={{likeCount: post.likes.length, isLike: false}} _id={post._id}/>
-            </div>
+            </>
+          )}
+          <div className="absolute right-[10px] bottom-[10px]">
+            <Tag>{post.channel.description}</Tag>
           </div>
         </div>
-    );
-  }
+      </Link>
+      <div className="flex h-[45%] flex-col justify-between">
+        <Link to={`/post/${post._id}`}>
+          <div className="h-[90px] p-[15px]">
+            <h3 className="nanum-gothic-bold line-clamp-1 pr-[30px] text-base">
+              {JSON.parse(post.title).title}
+            </h3>
+            <p className="nanum-gothic-regular line-clamp-2 text-sm">
+              {JSON.parse(post.title).body}
+            </p>
+          </div>
+        </Link>
+        <div className="mx-[10px] flex flex-row items-center justify-between border-t border-[#d9d9d9] px-[5px] py-[10px]">
+          <Info
+            size={30}
+            userName={post.author.fullName}
+            timestamp={post.createdAt}
+          />
+          <Interest
+            commentCount={post.comments.length}
+            like={{ likeCount: post.likes.length, isLike: false }}
+            _id={post._id}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/molecules/CommunityCard.tsx
+++ b/src/components/molecules/CommunityCard.tsx
@@ -7,19 +7,19 @@ import LogoImage from '../../assets/images/logo.png';
 // todo : Login 연결 후 isLike 동적으로 변경 필요함
 export default function CommunityCard({ post }: { post: Post }) {
   return (
-    <div className="h-[340px] w-[270px] rounded-[5px] border border-[#d9d9d9]">
+    <div className="rounded-top-[6px] h-[340px] w-[270px] rounded-[6px] border border-[#d9d9d9]">
       <Link to={`/post/${post._id}`}>
-        <div className="m-between relative h-[55%] rounded-t-[5px]">
+        <div className="m-between relative h-[55%]">
           {post.image ? (
             <>
               <img
                 src={post.image}
-                className="h-[100%] w-[100%] object-cover"
+                className="h-[100%] w-[100%] rounded-t-[5px] object-cover"
               />
             </>
           ) : (
             <>
-              <div className="cafe24 flex h-[100%] w-[100%] items-center justify-center gap-1 bg-[#A9907E] text-3xl leading-[0.9]">
+              <div className="cafe24 flex h-[100%] w-[100%] items-center justify-center gap-1 rounded-t-[5px] bg-[#755842] text-3xl leading-[0.9]">
                 <img src={LogoImage} className="h-[40%] w-auto"></img>
                 <p>
                   de:

--- a/src/components/templates/Community.tsx
+++ b/src/components/templates/Community.tsx
@@ -1,7 +1,66 @@
-export default function Community () {
+import CommunityCard from '../molecules/CommunityCard';
+import { getPostsByChannel } from '../../api/posts';
+import { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export default function Community() {
+  const location = useLocation();
+  const [posts, setPosts] = useState<Post[]>([]);
+
+  useEffect(() => {
+    const fetchPosts = async (channelId: string) => {
+      const posts = await getPostsByChannel(channelId);
+      setPosts(posts);
+    };
+
+    const fetchAllPosts = async () => {
+      const daily = await getPostsByChannel('681b6760bd535b296ed6fffc');
+      const develop = await getPostsByChannel('681b663760d7dc2aa8be1393');
+      const employ = await getPostsByChannel('681b669660d7dc2aa8be139b');
+      const recruit = await getPostsByChannel('681b66c660d7dc2aa8be139f');
+      setPosts(
+        [...daily, ...develop, ...employ, ...recruit].sort(
+          (a, b) =>
+            new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+        ),
+      );
+    };
+
+    switch (location.pathname) {
+      case '/community': {
+        fetchAllPosts();
+        break;
+      }
+      case '/community/daily': {
+        fetchPosts('681b6760bd535b296ed6fffc');
+        break;
+      }
+      case '/community/develop': {
+        fetchPosts('681b663760d7dc2aa8be1393');
+        break;
+      }
+      case '/community/employ': {
+        fetchPosts('681b669660d7dc2aa8be139b');
+        break;
+      }
+      case '/community/recruit': {
+        fetchPosts('681b66c660d7dc2aa8be139f');
+        break;
+      }
+    }
+  }, [location.pathname]);
+
   return (
     <>
-      <h1>Community Component</h1>
+      <div className="flex w-[90%] max-w-[1125px] min-w-[270px] flex-wrap justify-center gap-[15px]">
+        {posts.length !== 0 ? (
+          posts.map((post) => <CommunityCard key={post._id} post={post} />)
+        ) : (
+          <p className="nanum-gothic-regular text-base text-[#ababab]">
+            앗! 아직 작성된 게시물이 없어요!
+          </p>
+        )}
+      </div>
     </>
   );
 }

--- a/src/components/templates/Community.tsx
+++ b/src/components/templates/Community.tsx
@@ -1,7 +1,8 @@
 import CommunityCard from '../molecules/CommunityCard';
 import { getPostsByChannel } from '../../api/posts';
 import { useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
+import FloatingButton from '../atoms/FloatingButton';
 
 export default function Community() {
   const location = useLocation();
@@ -61,6 +62,9 @@ export default function Community() {
           </p>
         )}
       </div>
+      <Link to="/writer" className="fixed right-[10%] bottom-[5%]">
+        <FloatingButton buttonType="write" />
+      </Link>
     </>
   );
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #61

## 📝작업 내용

> 커뮤니티 페이지 퍼블리싱 및 로직 작성
- 반응형으로 한 줄에 보여지는 CommunityCard 개수 조정
- FloatingButton 클릭시 `/writer` 페이지로 이동
- SubNavigation 선택에 따라서 채널에 맞는 게시물 출력
    - 시간순 정렬
- 게시물이 1개도 없을 시 게시물이 없다는 메세지 출력 (추후 디자인 필요)

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/5e13640b-8ab7-4ab2-a8ff-938781cda907)
#### 반응형 예시
![image](https://github.com/user-attachments/assets/11c89f18-4c43-49dc-a2a8-69a5deb7fd0c)
#### 게시물이 없을 때
![image](https://github.com/user-attachments/assets/5a789358-f472-4d3f-b999-208eca49eeff)

