### PR TITLE
Feat : Question 페이지 제작

### DIFF
--- a/src/components/atoms/SubNavigation.tsx
+++ b/src/components/atoms/SubNavigation.tsx
@@ -12,8 +12,8 @@ const getTabData = (
   ],
   question: [
     { name: '전체', path: '/question' },
-    { name: '미해결', path: '/question/solved' },
-    { name: '해결완료', path: '/question/unsolved' },
+    { name: '미해결', path: '/question/unsolved' },
+    { name: '해결완료', path: '/question/solved' },
   ],
   users: [
     { name: '전체', path: '/users' },
@@ -21,10 +21,10 @@ const getTabData = (
     { name: '오프라인', path: '/users/offline' },
   ],
   userId: [
-    { name: '프로필', path: `/${userId}` },
-    { name: `${userId}의 질문`, path: `/${userId}/question` },
-    { name: '작성한 댓글', path: `/${userId}/comments` },
-    { name: '좋아요 누른 글', path: `/${userId}/liked` },
+    { name: '프로필', path: `/user/${userId}` },
+    { name: `${userId}의 질문`, path: `/user/${userId}/question` },
+    { name: '작성한 댓글', path: `/user/${userId}/comments` },
+    { name: '좋아요 누른 글', path: `/user/${userId}/liked` },
   ],
   me: [
     { name: '전체', path: '/me' },

--- a/src/components/molecules/QuestionCard.tsx
+++ b/src/components/molecules/QuestionCard.tsx
@@ -6,21 +6,23 @@ import { Link } from 'react-router-dom';
 
 export default function QuestionCard({ post }: { post: Post }) {
   return (
-    <div className="flex h-[182px] w-[100%] flex-col justify-between rounded-[5px] border border-[#d9d9d9]">
+    <div className="flex h-[190px] w-[100%] flex-col justify-between rounded-[5px] border border-[#d9d9d9]">
       <Link to={`/post/${post._id}`}>
-        <div className="flex flex-col p-[15px]">
-          <div className="inline-flex w-[100%] gap-[5px]">
-            <span className="nanum-gothic-bold max-w-[70%] overflow-hidden text-base break-all text-ellipsis whitespace-nowrap">
-              {JSON.parse(post.title).title}
-            </span>
-            {post.channel.description === '해결완료' && (
-              <Icon name="completeIcon" size={20} />
-            )}
+        <div className="items-between flex flex-col">
+          <div className="flex h-[90px] flex-col p-[15px]">
+            <div className="inline-flex w-[100%] gap-[5px]">
+              <span className="nanum-gothic-bold max-w-[70%] overflow-hidden text-base break-all text-ellipsis whitespace-nowrap">
+                {JSON.parse(post.title).title}
+              </span>
+              {post.channel.description === '해결완료' && (
+                <Icon name="completeIcon" size={20} />
+              )}
+            </div>
+            <div className="nanum-gothic-regular line-clamp-2 text-sm text-[#000000]">
+              {JSON.parse(post.title).body}
+            </div>
           </div>
-          <div className="nanum-gothic-regular line-clamp-2 text-sm text-[#000000]">
-            {JSON.parse(post.title).body}
-          </div>
-          <div className="mb-[10px] flex gap-[5px]">
+          <div className="flex gap-[5px] pl-[15px]">
             {JSON.parse(post.title)
               .tag.split(',')
               .map((t: string) => (

--- a/src/components/molecules/QuestionCard.tsx
+++ b/src/components/molecules/QuestionCard.tsx
@@ -2,60 +2,44 @@ import Tag from '../atoms/Tag';
 import Icon from '../atoms/Icon';
 import Info from '../atoms/Info';
 import Interest from '../atoms/Interest';
+import { Link } from 'react-router-dom';
 
-interface QuestionCardProps {
-  title: string;
-  content: string;
-  tags: string[];
-  name: string;
-  ImgUrl?: string;
-  timestamp: string | number | Date;
-  solved: boolean;
-  commentCount: number;
-  likeCount: number;
-  isLike: boolean;
-}
-
-export default function QuestionCard({
-  title,
-  content,
-  tags,
-  name,
-  ImgUrl,
-  timestamp,
-  solved,
-  commentCount,
-  likeCount,
-  isLike,
-}: QuestionCardProps) {
+export default function QuestionCard({ post }: { post: Post }) {
   return (
-    <div className="mx-auto h-[182px] w-[978px] rounded-[5px] border border-[#d9d9d9] p-[16px]">
-      <div className="mb-1 flex items-center">
-        <span className="nanum-gothic-bold mr-1 line-clamp-1 text-base text-[#000000]">
-          {title}
-        </span>
-        {/* solved가 true일 때 해결아이콘 */}
-        {solved && <Icon name="completeIcon" size={24} />}
-      </div>
-      <div className="nanum-gothic-regular mb-2 line-clamp-2 text-sm text-[#000000]">
-        {content}
-      </div>
-      <div className="mb-[10px] flex gap-[5px]">
-        {tags
-          .slice(0, 2)
-          .map(
-            (t) =>
-              t.trim() !== '' && (
-                <Tag className="">{t.trim().toUpperCase()}</Tag>
-              ),
-          )}
-      </div>
-      <div className="flex items-center justify-between border-t border-[#d9d9d9] pt-[6px]">
-        <Info imageUrl={ImgUrl} timestamp={timestamp} name={name} />
+    <div className="flex h-[182px] w-[100%] flex-col justify-between rounded-[5px] border border-[#d9d9d9]">
+      <Link to={`/post/${post._id}`}>
+        <div className="flex flex-col p-[15px]">
+          <div className="inline-flex w-[100%] gap-[5px]">
+            <span className="nanum-gothic-bold max-w-[70%] overflow-hidden text-base break-all text-ellipsis whitespace-nowrap">
+              {JSON.parse(post.title).title}
+            </span>
+            {post.channel.description === '해결완료' && (
+              <Icon name="completeIcon" size={20} />
+            )}
+          </div>
+          <div className="nanum-gothic-regular line-clamp-2 text-sm text-[#000000]">
+            {JSON.parse(post.title).body}
+          </div>
+          <div className="mb-[10px] flex gap-[5px]">
+            {JSON.parse(post.title)
+              .tag.split(',')
+              .map((t: string) => (
+                <Tag>{t}</Tag>
+              ))}
+          </div>
+        </div>
+      </Link>
+      <div className="mx-[10px] flex flex-row items-center justify-between border-t border-[#d9d9d9] px-[5px] py-[10px]">
+        <Info
+          size={30}
+          userName={post.author.fullName}
+          timestamp={post.createdAt}
+          imageUrl={post.author.image}
+        />
         <Interest
-          commentCount={commentCount}
-          likeCount={likeCount}
-          isLike={isLike}
+          commentCount={post.comments.length}
+          like={{ likeCount: post.likes.length, isLike: false }}
+          _id={post._id}
         />
       </div>
     </div>

--- a/src/components/molecules/QuestionCard.tsx
+++ b/src/components/molecules/QuestionCard.tsx
@@ -23,11 +23,9 @@ export default function QuestionCard({ post }: { post: Post }) {
             </div>
           </div>
           <div className="flex gap-[5px] pl-[15px]">
-            {JSON.parse(post.title)
-              .tag.split(',')
-              .map((t: string) => (
-                <Tag>{t}</Tag>
-              ))}
+            {JSON.parse(post.title).tags.map((t: string, index: number) => (
+              <Tag key={index}>{t}</Tag>
+            ))}
           </div>
         </div>
       </Link>

--- a/src/components/templates/Question.tsx
+++ b/src/components/templates/Question.tsx
@@ -31,11 +31,11 @@ export default function Question() {
         break;
       }
       case '/question/unsolved': {
-        fetchPosts('681b66f960d7dc2aa8be13a8');
+        fetchPosts('681b66f060d7dc2aa8be13a3');
         break;
       }
       case '/question/solved': {
-        fetchPosts('681b66f060d7dc2aa8be13a3');
+        fetchPosts('681b66f960d7dc2aa8be13a8');
         break;
       }
     }

--- a/src/components/templates/Question.tsx
+++ b/src/components/templates/Question.tsx
@@ -1,7 +1,60 @@
-export default function Question () {
+import QuestionCard from '../molecules/QuestionCard';
+import { getPostsByChannel } from '../../api/posts';
+import { useEffect, useState } from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import FloatingButton from '../atoms/FloatingButton';
+
+export default function Question() {
+  const location = useLocation();
+  const [posts, setPosts] = useState<Post[]>([]);
+
+  useEffect(() => {
+    const fetchPosts = async (channelId: string) => {
+      const posts = await getPostsByChannel(channelId);
+      setPosts(posts);
+    };
+
+    const fetchAllPosts = async () => {
+      const solved = await getPostsByChannel('681b66f960d7dc2aa8be13a8');
+      const unsolved = await getPostsByChannel('681b66f060d7dc2aa8be13a3');
+      setPosts(
+        [...solved, ...unsolved].sort(
+          (a, b) =>
+            new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+        ),
+      );
+    };
+
+    switch (location.pathname) {
+      case '/question': {
+        fetchAllPosts();
+        break;
+      }
+      case '/question/unsolved': {
+        fetchPosts('681b66f960d7dc2aa8be13a8');
+        break;
+      }
+      case '/question/solved': {
+        fetchPosts('681b66f060d7dc2aa8be13a3');
+        break;
+      }
+    }
+  }, [location.pathname]);
+
   return (
     <>
-      <h1>Question Component</h1>
+      <div className="flex w-[260px] flex-wrap justify-center gap-[15px] sm:w-[260px] md:w-[535px] lg:w-[810px] xl:w-[1125px]">
+        {posts.length !== 0 ? (
+          posts.map((post) => <QuestionCard key={post._id} post={post} />)
+        ) : (
+          <p className="nanum-gothic-regular text-base text-[#ababab]">
+            앗! 아직 작성된 게시물이 없어요!
+          </p>
+        )}
+      </div>
+      <Link to="/writer" className="fixed right-[10%] bottom-[5%]">
+        <FloatingButton buttonType="write" />
+      </Link>
     </>
   );
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #64

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
 Question 템플릿 퍼블리싱 및 로직
- 반응형으로 한 줄에 보여지는 CommunityCard 개수 조정
- 해결완료 시 제목 옆에 해결 아이콘 출력
- FloatingButton 클릭시 `/writer` 페이지로 이동
- SubNavigation 선택에 따라서 채널에 맞는 게시물 출력
    - 시간순 정렬
- 게시물이 1개도 없을 시 게시물이 없다는 메세지 출력 (추후 디자인 필요)

## 수정한 컴포넌트
### QuestionCard
- props 변경 및 디자인 수정

### SubNavigation
- path 변경 (solved <-> unsolved)

### 스크린샷 (선택)
#### 전체 화면
Card 내부가 좀 비어보이는데, body가 두줄일땐 괜찮습니다!
![image](https://github.com/user-attachments/assets/80db46ec-fa47-459f-99e6-b4c91bb658f5)
#### 반응형 예시
![image](https://github.com/user-attachments/assets/62f84da1-e0f2-4ba5-93a1-c5ba7a8a9551)
