### PR TITLE
Fix : UserCard.tsx #46 - tag 빈값 문구 추가 및 tag 유무에 따라 있던 높이 값 차이 제거

### DIFF
--- a/src/components/molecules/UserCard.tsx
+++ b/src/components/molecules/UserCard.tsx
@@ -21,7 +21,7 @@ export default function UserCard({
   loginStatus,
 }: UserCardProps) {
   return (
-    <div className="dark:border-dark-border dark:bg-dark-card dark:text-dark-text flex h-[140px] w-[310px] gap-4 rounded-[5px] border border-[#d9d9d9] p-5 duration-300 hover:shadow-md dark:shadow-black">
+    <div className="dark:border-dark-border dark:bg-dark-card dark:text-dark-text flex h-[140px] w-[310px] gap-4 rounded-[5px] border border-[#d9d9d9] p-5">
       <div className="flex-shrink-0">
         <UserAvatar
           size={100}
@@ -30,19 +30,25 @@ export default function UserCard({
           status={loginStatus}
         />
       </div>
-      <div className="flex flex-col justify-evenly gap-3">
-        <div className="flex flex-col">
+      <div className="flex flex-1 flex-col justify-evenly">
+        <div>
           <UserName name={UName} className="nanum-gothic-bold text-[16px]" />
-          <div className="flex flex-col gap-0.5">
-            <ul className="flex flex-wrap gap-1 leading-none">
-              {tags.slice(0, 2).map((t) =>
-                t.trim() !== '' ? (
-                  <li key={t.trim().toUpperCase()}>
-                    <Tag>{t.trim().toUpperCase()}</Tag>
-                  </li>
-                ) : null,
-              )}
-            </ul>
+          <div className="fmin-h-[24px] flex items-center">
+            {tags.length > 0 ? (
+              <ul className="flex flex-wrap gap-1 leading-none">
+                {tags.slice(0, 2).map((t) =>
+                  t.trim() !== '' ? (
+                    <li key={t.trim().toUpperCase()}>
+                      <Tag>{t.trim().toUpperCase()}</Tag>
+                    </li>
+                  ) : null,
+                )}
+              </ul>
+            ) : (
+              <span className="h-[22px] text-[12px] text-[#ABABAB]">
+                설정한 기술 스택이 없습니다.
+              </span>
+            )}
           </div>
         </div>
         <div className="nanum-gothic-regular flex items-baseline gap-4 text-[12px]">


### PR DESCRIPTION
## #️⃣연관된 이슈

> #46 

## 📝작업 내용

> tag 빈값 문구 추가 및 tag 유무에 따라 있던 높이 값 차이 제거

### 스크린샷 (선택)
<img width="436" alt="스크린샷 2025-05-19 오전 2 34 16" src="https://github.com/user-attachments/assets/e8e93e25-dee0-4d8a-8cde-4ccc774050fd" /><img width="436" alt="스크린샷 2025-05-19 오전 2 34 42" src="https://github.com/user-attachments/assets/482c39a7-eb9e-44b5-ae40-6ab2784a76a8" />



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
